### PR TITLE
don't stretch images

### DIFF
--- a/src/components/skill-widget.vue
+++ b/src/components/skill-widget.vue
@@ -98,5 +98,6 @@
     display: block;
     height: 100%;
     width: 100%;
+    object-fit: contain;
   }
 </style>


### PR DESCRIPTION
if the images are allowed to fill their containers with 100%,100% they'll stretch out; with object-fit: contain they stay nicely within the borders and image ratio.